### PR TITLE
rename "rekate" to "retake" in delegate and allow retake to be called programmatically

### DIFF
--- a/VLBCameraView/VLBCameraView.h
+++ b/VLBCameraView/VLBCameraView.h
@@ -94,7 +94,7 @@ extern VLBCameraViewMeta const VLBCameraViewMetaOriginalImage;
  @param cameraView the VLBCameraView intance that this delegate is assigned to.
  @param image current image currently previewing.
  */
--(void)cameraView:(VLBCameraView*)cameraView willRekatePicture:(UIImage *)image;
+-(void)cameraView:(VLBCameraView*)cameraView willRetakePicture:(UIImage *)image;
 
 /**
  Implement if VLBCameraView.writeToCameraRoll is set to YES.
@@ -165,5 +165,14 @@ extern VLBCameraViewMeta const VLBCameraViewMetaOriginalImage;
  */
 - (void)takePicture;
 
+/**
+ 
+ Restart the take picture session as if the user had tapped on the view with the VLBCameraView#allowPictureRetake property set to YES. 
+ 
+ Does not block.
+
+ @callback on the main thread at VLBCameraViewDelegate#cameraView:willRetakePicture:
+ */
+- (void) retakePicture;
 
 @end

--- a/VLBCameraView/VLBCameraView.m
+++ b/VLBCameraView/VLBCameraView.m
@@ -235,12 +235,16 @@ return ^(CMSampleBufferRef imageDataSampleBuffer, NSError *error)
     }
 }
 
-- (void)retakePicture:(UITapGestureRecognizer*) tapToRetakeGesture
-{
-    [self.delegate cameraView:self willRekatePicture:self.preview.image];
+- (void)retakePicture {
+    [self.delegate cameraView:self willRetakePicture:self.preview.image];
     
     self.preview.image = nil;
     [self.session startRunning];
+}
+
+- (void)retakePicture:(UITapGestureRecognizer*) tapToRetakeGesture
+{
+    [self retakePicture];
 }
 
 @end


### PR DESCRIPTION
fixes #5 and adds retakePicture to public api
